### PR TITLE
:building_construction: change document to be ran in GitHub actions.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,5 +9,5 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 
 [{*.yaml,*.yml}]
-indent_size = 2
+indent_size = 4
 indent_style = space

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,8 +1,8 @@
-name: Test
+name: Build and test
 on: [push]
 jobs:
     build:
-        name: Build
+        name: Build and test
         runs-on: ubuntu-latest
         steps:
             - name: Use Checkout 2

--- a/.github/workflows/document.yaml
+++ b/.github/workflows/document.yaml
@@ -1,0 +1,36 @@
+name: Document
+on:
+    push:
+        branches:
+            - main
+        paths: ["./.storybook/**", "src/**"]
+jobs:
+    build:
+        name: Document
+        runs-on: ubuntu-latest
+        steps:
+            - name: Use Checkout 2
+              uses: actions/checkout@v2
+
+            - name: Use Node.js 16
+              uses: actions/setup-node@v1
+              with:
+                  node-version: 16.x
+
+            - name: Use pnpm 6
+              uses: pnpm/action-setup@v2
+              with:
+                  version: 6.x
+                  run_install: true
+
+            - name: Storybook (Pre-install)
+              run: pnpm document
+
+            - name: Storybook (Deploy)
+              uses: JamesIves/github-pages-deploy-action@3.6.2
+              with:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  BRANCH: ${GITHUB_REF#refs/*/}
+                  FOLDER: docs-build
+                  CLEAN: true
+                  TARGET_FOLDER: docs

--- a/.gitignore
+++ b/.gitignore
@@ -149,6 +149,7 @@ $RECYCLE.BIN/
 *.lnk
 
 # Build
+docs-build
 cjs
 esm
 dist
@@ -157,3 +158,4 @@ dist-ssr
 
 # Lockfiles
 pnpm-lock.yaml
+yarn.lock

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
 	"homepage": "https://react-components.laserreindeer.com",
 	"husky": {
 		"hooks": {
-			"pre-push": "run-s clean pre-compile lint test docs"
+			"pre-push": "run-s clean pre-compile lint test"
 		}
 	},
 	"keywords": [
@@ -101,7 +101,7 @@
 		"compile": "run-s compile:*",
 		"compile:cjs": "tsc --project tsconfig.cjs.json",
 		"compile:esm": "tsc --project tsconfig.esm.json",
-		"docs": "build-storybook --no-dll --static-dir ./.storybook/public --output-dir ./docs",
+		"document": "build-storybook --no-dll --static-dir ./.storybook/public --output-dir ./docs-build",
 		"lint": "eslint src/**/*.{ts,tsx}",
 		"lint:fix": "eslint src/**/*.{ts,tsx} --fix",
 		"postpublish": "run-s clean",


### PR DESCRIPTION
Should close #11 

I basically added 2 Actions, 1 runs in every branch (build+test), the other runs only on main and only when we change either the stories or the components, and it builds the docs from there 😄 